### PR TITLE
Remove extra parameters passed to parent construct

### DIFF
--- a/Controller/Adminhtml/Region/NewAction.php
+++ b/Controller/Adminhtml/Region/NewAction.php
@@ -37,7 +37,7 @@ class NewAction extends \Magento\Backend\App\Action
     ) {
         $this->coreRegistry = $coreRegistry;
         $this->resultPageFactory = $resultPageFactory;
-        parent::__construct($context, $coreRegistry);
+        parent::__construct($context);
     }
 
     /**


### PR DESCRIPTION
When execute **setup:di:compile**, failed compiled with the following error:

**Extra parameters passed to parent construct**

Tested on Magento 2.1.5